### PR TITLE
feat(layout): add Expanded component for flex layouts

### DIFF
--- a/src/layout/deno.json
+++ b/src/layout/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@html-props/layout",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "exports": "./mod.ts",
   "tasks": {
     "test": "deno test --allow-read --allow-env"

--- a/src/layout/expanded.ts
+++ b/src/layout/expanded.ts
@@ -1,0 +1,57 @@
+import {
+  type HTMLPropsElementConstructor,
+  HTMLPropsMixin,
+  type InferConstructorProps,
+  type InferProps,
+  type Prop,
+  prop,
+} from '@html-props/core';
+
+const config: {
+  flex: Prop<number>;
+  style: { display: string; minWidth: string; minHeight: string };
+} = {
+  flex: prop(1),
+  style: { display: 'block', minWidth: '0', minHeight: '0' },
+};
+
+const ExpandedBase:
+  & HTMLPropsElementConstructor<
+    typeof HTMLElement,
+    InferConstructorProps<typeof config>,
+    InferProps<typeof config>
+  >
+  & Pick<typeof HTMLElement, keyof typeof HTMLElement> = HTMLPropsMixin(
+    HTMLElement,
+    config,
+  );
+
+/**
+ * Expanded component for flex layouts.
+ *
+ * A widget that expands a child of a Row, Column, or Flex
+ * so that the child fills the available space.
+ *
+ * Using an Expanded widget makes a child of a Row, Column, or Flex
+ * expand to fill the available space along the main axis.
+ *
+ * @example
+ * ```typescript
+ * new Row({
+ *   content: [
+ *     new Icon({ name: "search" }),
+ *     new Expanded({
+ *       content: new Input({ placeholder: "Search..." }),
+ *     }),
+ *     new Button({ content: ["Go"] }),
+ *   ],
+ * });
+ * ```
+ */
+export class Expanded extends ExpandedBase {
+  render() {
+    this.style.flex = String(this.flex);
+  }
+}
+
+Expanded.define('layout-expanded');

--- a/src/layout/mod.ts
+++ b/src/layout/mod.ts
@@ -1,5 +1,6 @@
 export * from './flex_types.ts';
 export * from './row.ts';
+export * from './expanded.ts';
 export * from './stack.ts';
 export * from './center.ts';
 export * from './padding.ts';


### PR DESCRIPTION
## Summary

Adds `Expanded` component to the layout package. This makes a child of a `Row`, `Column`, or `Flex` expand to fill the available space along the main axis.

Similar to Flutter's `Expanded` widget.

## Usage

```typescript
import { Row, Expanded } from "@html-props/layout";
import { Input, Button } from "@html-props/built-ins";

new Row({
  gap: "12px",
  content: [
    new Icon({ name: "search" }),
    new Expanded({
      content: new Input({ placeholder: "Search..." }),
    }),
    new Button({ content: ["Go"] }),
  ],
});
```

## Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `flex` | `number` | `1` | The flex grow factor |

## Implementation Details

- Sets `flex` style property based on `flex` prop
- Sets `minWidth: 0` and `minHeight: 0` to allow shrinking below content size (fixes common flex layout issue)
- Registered as `<layout-expanded>` custom element