### PR TITLE
fix: resolve shadow option from default prop config

### DIFF
--- a/src/core/mixin.ts
+++ b/src/core/mixin.ts
@@ -84,15 +84,31 @@ export function HTMLPropsMixin<T extends Constructor, POrConfig = {}>(
 
       const props = args[0] ?? {};
 
+      // Create controller with props config
+      const propsConfig = (this.constructor as any).__propsConfig as PropsConfig || {};
+
       // Handle declarative shadow DOM option
-      const shadowOpt = props.shadow ?? (this.constructor as any).shadow;
+      const shadowPropConfig = propsConfig.shadow;
+      let defaultShadow: any = undefined;
+      if (shadowPropConfig !== undefined) {
+        if (
+          shadowPropConfig && typeof shadowPropConfig === 'object' &&
+          ('default' in shadowPropConfig || 'type' in shadowPropConfig || 'attribute' in shadowPropConfig)
+        ) {
+          defaultShadow = shadowPropConfig.default;
+        } else {
+          defaultShadow = shadowPropConfig;
+        }
+      }
+
+      const shadowOpt = props.shadow ?? (this.constructor as any).shadow ?? defaultShadow;
       if (shadowOpt && !this.shadowRoot) {
-        const shadowInit = typeof shadowOpt === 'object' ? shadowOpt : { mode: 'open' };
+        const shadowInit = typeof shadowOpt === 'object'
+          ? shadowOpt
+          : { mode: (shadowOpt === 'closed' || shadowOpt === 'open') ? shadowOpt : 'open' };
         this.attachShadow(shadowInit);
       }
 
-      // Create controller with props config
-      const propsConfig = (this.constructor as any).__propsConfig as PropsConfig || {};
       this[PROPS_CONTROLLER] = new PropsController(this, propsConfig, props);
     }
 

--- a/src/core/tests/shadow.test.ts
+++ b/src/core/tests/shadow.test.ts
@@ -1335,6 +1335,37 @@ Deno.test({
       assertEquals(result.shadowText, 'Static Shadow!');
     });
 
+    await t.step('shadow option from default prop config attaches shadow root', async () => {
+      await ctx.page.reload();
+      await loadTestPage(ctx.page, {
+        code: `
+          class MyElConfig extends HTMLPropsMixin(HTMLElement, {
+            shadow: prop("open", { attribute: "shadow" }),
+          }) {
+            render() {
+              return "Config Shadow!";
+            }
+          }
+          MyElConfig.define("my-el-config-shadow");
+
+          const el = new MyElConfig();
+          document.body.appendChild(el);
+          (window as any).el = el;
+        `,
+      });
+
+      const result = await ctx.page.evaluate(() => {
+        const el = (window as any).el;
+        return {
+          hasShadow: el.shadowRoot !== null,
+          shadowText: el.shadowRoot?.textContent,
+        };
+      });
+
+      assertEquals(result.hasShadow, true);
+      assertEquals(result.shadowText, 'Config Shadow!');
+    });
+
     // Teardown
     await teardownBrowser(ctx);
   },


### PR DESCRIPTION
This PR resolves issue #52 by ensuring that the `shadow` configuration option can be successfully resolved from the default value defined in the component's `props` config.

### Proposed Changes
- Modified [mixin.ts](file:///var/home/atzufuki/Code/html-props/src/core/mixin.ts) to extract default `shadow` configuration from `propsConfig` when `props.shadow` and `static shadow` are not provided.
- Correctly parsed the `shadow` mode when specified as a string (`'open'` or `'closed'`).
- Added a unit test in [shadow.test.ts](file:///var/home/atzufuki/Code/html-props/src/core/tests/shadow.test.ts) to verify shadow root creation via default prop configuration.

## Verification Results
- [x] All Deno tests passed successfully (`deno task test`).
- [x] Core package lint and format verified (`deno lint src/core/ && deno fmt --check src/core/`).

## Related Issues
- Closes #52
